### PR TITLE
Add error handling middlewares

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
 
+const errorHandler = require('./middlewares/errorHandler');
+const routeNotFound = require('./middlewares/routeNotFound');
+
 const routes = require('./routes');
 const app = express();
 
@@ -14,5 +17,8 @@ mongoose.connect(process.env.MONGO_URL, {
 app.use(cors());
 app.use(express.json());
 app.use(routes);
+
+app.use(routeNotFound);
+app.use(errorHandler);
 
 app.listen(process.env.PORT || 3333);

--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -1,0 +1,5 @@
+module.exports = (error, _request, response, _next) => {
+  const { status, ...err } = error;
+
+  return response.status(status || 500).send(err)
+}

--- a/src/middlewares/routeNotFound.js
+++ b/src/middlewares/routeNotFound.js
@@ -1,0 +1,9 @@
+module.exports = (request, _response, next) => {
+  return next({
+    status: 404,
+    error: 'Route not found.',
+    details: {
+      resource: `The resource ${request.path} could not be found.`,
+    }
+  });
+}


### PR DESCRIPTION
Added **errorHandler.js** and **routeNotFound.js** middlewares.

http://expressjs.com/en/guide/error-handling.html

**routeNotFound.js** will act only when the resource that the client is trying to access does not correspond to any of the ones available in the API.

Sample input:

> GET: /noexist

Sample output:
```
GET: /noexist
Status: 404 Not Found

{
  "error": "Route not found.",
  "details": {
    "resource": "The resource /noexist could not be found."
  }
}
```

Now the output message you see is from **errorHandler.js**, which will be available throughout the Express app.