### PR TITLE
Update general environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-APP_URL=http://localhost:3333
-
-MONGO_URL=mongodb+srv://omnistack:omnistack@omnistack-vgqln.mongodb.net/devchallenge?retryWrites=true&w=majority

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+APP_URL = http://localhost:3333
+
+MONGO_URL = mongodb://localhost:27017/devchallenge-dev

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# The URL from where your Express Web app is running.
+APP_URL = YOUR_APP_URL
+
+# This will be your MongoDB connection string.
+# Whether from MongoDB Atlas or a local instance.
+# For more information: https://www.mongodb.com/what-is-mongodb
+MONGO_URL = YOUR_MONGODB_CONNECTION_STRING.
+
+# To still be added. Represent the JSON Web Token key
+# for token generation and verification.
+SECRET = YOUR_SUPER_SECRET_JWT_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+node_modules/
+.env

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "NODE_ENV": "development"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
-require('dotenv').config();
+require('dotenv').config({
+    path: process.env.NODE_ENV === 'production'
+        ? '.env'
+        : `.env.${process.env.NODE_ENV}`
+});
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');


### PR DESCRIPTION
This PR update **.env** for security purposes. The main reason for doing this it's because your MongoDB Atlas' Cluster login and password is visible.

### Notable changes
Added an `.env.example` file to describe the variables function throughout the application.

Added `.env` on `.gitignore` to prevent production environment details being pushed to the remote repository.

Renamed `.env` to `.env.development` and changed `MONGO_URL` to a local MongoDB instance url.

Among the changes, `nodemon.json` has also been added. At the moment, its only function is to set the current environment to development mode, but soon enough will be used to configure VS Code live debugger.

### Notes
It's recommended that you change your MongoDB Atlas' Cluster login and password since it's still visible in older commits. You can maintain the production `.env` on Heroku's remote repository.