### PR TITLE
Adição do Docker e Compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+## node.js
+#
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+ENV MONGO_URL=mongodb://mongodb/dev-challenge-dev
+ENV PORT=3333
+
+EXPOSE ${PORT}
+
+ENTRYPOINT ["npm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . .
 
-ENV MONGO_URL=mongodb://mongodb/dev-challenge-dev
+ENV MONGO_URL=mongodb://mongodb/devchallenge-dev
 ENV PORT=3333
 
 EXPOSE ${PORT}

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -78,4 +78,4 @@ $ docker-compose build && docker-compose up -d
 
 **Nota:** O servidor e a instância do MongoDB estará rodando nas portas 3001 e 3002, respectivamente.
 
-E você estará pronto para ir!
+E você está pronto para ir!

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,7 +1,12 @@
 # Instalação
 Essas instruções vão te levar a uma cópia do projeto rodando em sua máquina local para propósitos de testes e desenvolvimento.
 
-## Pré-requisitos
+## Tabela de conteúdos
+- [Instalação padrão](#instalação-padrão)
+- [Instalação com Docker](#instalação-com-docker)
+
+## Instalação padrão
+### Pré-requisitos
 - [Node.js](https://nodejs.org/pt-br/download/) versão 12 ou superior
 - Gerenciador de pacotes (Yarn ou NPM)
 - Uma [instância local](https://docs.mongodb.com/manual/installation/#mongodb-community-edition-installation-tutorials) ou um [cluster](https://www.mongodb.com/cloud/atlas) do MongoDB rodando
@@ -27,7 +32,7 @@ $ npm install
 ```
 
 ### Configurando as variáveis de ambiente
-(Opcional) Crie um arquivo na raiz do projeto chavado `.env`.
+**(OPCIONAL)** Crie um arquivo na raiz do projeto chavado `.env`.
 
 ```
 APP_URL={A URL em que o seu app está hospedado}
@@ -47,3 +52,30 @@ ou
 ```bash
 $ npm run dev
 ```
+
+E você está pronto para ir!
+
+## Instalação com Docker
+Por padrão, instalar o projeto com o Docker Compose o inicializará como um ambiente de desenvolvimento.
+
+### Pré-requisitos
+- [Docker](https://docs.docker.com/engine/install/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Clonando o repositório
+```bash
+$ git clone https://github.com/Lorenalgm/DevChallengeAPI.git
+
+$ cd DevChallengeAPI
+```
+
+Ou se preferir, faça o [download](https://github.com/Lorenalgm/DevChallengeAPI/archive/master.zip) do projeto.
+
+### Inicializando os contêineres
+```bash
+$ docker-compose build && docker-compose up -d
+```
+
+**Nota:** O servidor e a instância do MongoDB estará rodando nas portas 3001 e 3002, respectivamente.
+
+E você estará pronto para ir!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.3"
+
+services:
+  backend:
+    container_name: "devchallenge_api"
+    build:
+      context: ./
+    environment:
+      - "PORT=3333"
+    ports:
+      - "3001:3333"
+    networks:
+      - "database"
+    volumes:
+      - type: "bind"
+        source: "."
+        target: "/app"
+    depends_on:
+      - "mongodb"
+  mongodb:
+    image: "mongo"
+    container_name: "devchallenge_database"
+    volumes:
+      - "db-data:/data/db"
+    networks:
+      - "database"
+    ports:
+      - "3002:27017"
+
+networks:
+  database:
+
+volumes:
+  db-data:


### PR DESCRIPTION
Adição do Docker e do Docker Compose para auxiliar o ambiente de desenvolvimento local

As alterações foram feitas para evitar que serviços como MongoDB - e futuramente, o Redis - estejam em constante execução na máquina do desenvolvedor

Atualmente com dois serviços - API e MongoDB - pré-definidos para serem executados nas portas 3001 e 3002 respectivamente

Volumes e networks foram definidos para auxiliar no processo de desenvolvimento. Ou seja, o aplicativo web será reinicializado no momento que algum arquivo for alterado e os registros na base de dados permanecerão caso haja a necessidade de reiniciar/reconstruir os contêineres e imagens

Os detalhes sobre como instalar  também foram adicionados ao [guia de instalação](https://github.com/Lorenalgm/DevChallengeAPI/blob/docker/INSTALLING.md)
