### PR TITLE
FEAT: Filtering Utils and ENUM with Allowed Filters for the Controllers

### DIFF
--- a/src/shared/enums/FilteringEnum.js
+++ b/src/shared/enums/FilteringEnum.js
@@ -1,0 +1,7 @@
+const FilteringEnum = {
+  ALLOWED_FILTERS: {
+    challenges: ['type', 'level', 'techs']
+  }
+};
+
+module.exports = FilteringEnum;

--- a/src/shared/utils/Filtering.js
+++ b/src/shared/utils/Filtering.js
@@ -1,0 +1,20 @@
+class Filtering {
+  static getFilters(queryString, allowedFilters) {
+    const properties = Object.keys(queryString);
+
+    const filters = properties.reduce((filtersAcc, property) => {
+      const isFilterAllowed = allowedFilters.includes(property);
+      const isPropertyValueValid = !!queryString[property];
+
+      if (isFilterAllowed && isPropertyValueValid) {
+        return { ...filtersAcc, [property]: queryString[property] };
+      }
+
+      return { ...filtersAcc };
+    }, {});
+
+    return filters;
+  }
+}
+
+module.exports = Filtering;


### PR DESCRIPTION
We implemented filtering for challenges, but it is something that is going to be repeated in requests for others database queries. To comply with the DRY principle I abstracted it into the utils module that can be reused whenever we apply filter to another request.

**Why?**
-Dry principle: otherwise the filters would be repeated on each controller.
-Better maintainability: it is better to have a place with all the enums responsible for setting the allowed filters options. It makes it easier to modify the allowed filters in the future instead of looking for them in the code base scattered throughout each controller.

**Check-list:**
⬜ The pull request solves an issue.
✅ Executing npm run test will pass all implemented test suites (Including lint).
⬜ Added new tests to prevent bugs.
✅ Updated the docs according to modifications in the source code (If applicable).
✅ Read and followed the project's contribution guide.